### PR TITLE
feat: Configure for Vercel deployment and fix runtime error

### DIFF
--- a/app/auth/error/page.tsx
+++ b/app/auth/error/page.tsx
@@ -114,19 +114,19 @@ function ErrorContent() {
           <CardContent className="space-y-4">
             <div className="flex flex-col space-y-2">
               {errorInfo.canRetry && (
-                <Button asChild className="w-full">
-                  <Link href="/api/auth/login">
+                <Link href="/api/auth/login" passHref className="w-full">
+                  <Button className="w-full">
                     <RefreshCw className="mr-2 h-4 w-4" />
                     Try Again
-                  </Link>
-                </Button>
+                  </Button>
+                </Link>
               )}
-              <Button variant="outline" asChild className="w-full">
-                <Link href="/">
+              <Link href="/" passHref className="w-full">
+                <Button variant="outline" className="w-full">
                   <Home className="mr-2 h-4 w-4" />
                   Go Home
-                </Link>
-              </Button>
+                </Button>
+              </Link>
             </div>
             
             <div className="mt-6 text-center">

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -17,7 +17,7 @@ export interface EpicConfig {
 export function getEpicConfig(): EpicConfig {
   const config: EpicConfig = {
     clientId: process.env.CLIENT_ID || '',
-    redirectUri: process.env.REDIRECT_URI || 'http://localhost:3000/auth/callback',
+    redirectUri: process.env.REDIRECT_URI || 'http://localhost:3000/api/auth/callback',
     baseUrl: process.env.FHIR_BASE_URL || 'https://fhir.epic.com/interconnect-fhir-oauth/api/FHIR/R4/',
     authorizeUrl: process.env.EPIC_AUTHORIZE_URL || 'https://fhir.epic.com/interconnect-fhir-oauth/oauth2/authorize',
     tokenUrl: process.env.EPIC_TOKEN_URL || 'https://fhir.epic.com/interconnect-fhir-oauth/oauth2/token',
@@ -57,8 +57,8 @@ export function validateEpicConfig(): { valid: boolean; errors: string[] } {
     // Validate redirect URI format
     try {
       const url = new URL(config.redirectUri);
-      if (url.pathname !== '/auth/callback') {
-        errors.push('REDIRECT_URI must end with /auth/callback');
+      if (url.pathname !== '/api/auth/callback') {
+        errors.push('REDIRECT_URI must end with /api/auth/callback');
       }
       if (url.protocol !== 'http:' && url.protocol !== 'https:') {
         errors.push('REDIRECT_URI must use http or https protocol');


### PR DESCRIPTION
This commit addresses two issues:
1.  It updates the application's configuration to support deployment to Vercel. This includes correcting the default redirect URI to use the `/api` path and updating the validation logic accordingly.
2.  It fixes a `React.Children.only` runtime error on the authentication error page (`/auth/error`). The error was caused by an incorrect nesting of `shadcn/ui`'s `Button` component with Next.js's `Link` component. The code has been refactored to use the correct and recommended pattern, which is to wrap the `Button` with the `Link` and use the `passHref` prop.

These changes unblock the Vercel deployment and ensure the application runs correctly in a production environment.