### PR TITLE
feat: Configure for Vercel and fix runtime errors

### DIFF
--- a/app/test-login/page.tsx
+++ b/app/test-login/page.tsx
@@ -133,21 +133,21 @@ export default function TestLoginPage() {
             </CardHeader>
             <CardContent>
               <div className="flex gap-2 flex-wrap">
-                <Button variant="outline" asChild>
-                  <a href="/api/epic-test" target="_blank">
+                <a href="/api/epic-test" target="_blank" rel="noopener noreferrer">
+                  <Button variant="outline">
                     View Auth Config
-                  </a>
-                </Button>
-                <Button variant="outline" asChild>
-                  <a href="/debug" target="_blank">
+                  </Button>
+                </a>
+                <a href="/debug" target="_blank" rel="noopener noreferrer">
+                  <Button variant="outline">
                     Debug Console
-                  </a>
-                </Button>
-                <Button variant="outline" asChild>
-                  <a href="/status" target="_blank">
+                  </Button>
+                </a>
+                <a href="/status" target="_blank" rel="noopener noreferrer">
+                  <Button variant="outline">
                     App Status
-                  </a>
-                </Button>
+                  </Button>
+                </a>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
This commit prepares the application for Vercel deployment and resolves critical runtime errors.

The main changes include:
- Updating the default `REDIRECT_URI` in the configuration to use the correct `/api/auth/callback` path and updating the associated validation logic.
- Fixing a `React.Children.only` runtime error that occurred on the `/auth/error` and `/test-login` pages. The error was caused by an incorrect nesting of `shadcn/ui`'s `Button` component with `Link` or `<a>` tags when using the `asChild` prop. The code has been refactored to use a more robust and standard pattern that avoids this issue.

These changes unblock the Vercel deployment and ensure the application runs correctly in a production environment.