### PR TITLE
fix: Resolve Epic OAuth flow and fix project build

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,7 +1,8 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    'tailwindcss': {},
+    'autoprefixer': {},
   },
 }
 


### PR DESCRIPTION
This commit includes multiple fixes to resolve issues with the Epic FHIR integration and the project's build process.

1.  **Harden OAuth Configuration:**
    - The `redirect_uri` is now programmatically built from `NEXTAUTH_URL` or `VERCEL_URL` to ensure it always uses `https` and is correctly formatted for deployed environments.
    - Replaced the generic `patient/*.read` scope with a specific list of `Read` and `Search` scopes to match the Epic app's configuration, preventing authorization errors.

2.  **Fix Build Error:**
    - Corrected the `postcss.config.mjs` file by replacing the outdated `@tailwindcss/postcss` plugin with `tailwindcss` and adding the standard `autoprefixer` plugin. This resolves the `Cannot find module` error and allows the project to build successfully.