### PR TITLE
fix(config): Resolve module not found error for aliased paths

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,7 @@ const customJestConfig = {
     '!**/*.d.ts',
     '!**/node_modules/**',
   ],
-  moduleNameMapping: {
+  moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,9 +20,7 @@
     ],
     "baseUrl": ".",
     "paths": {
-      "@/components/*": ["components/*"],
-      "@/lib/*": ["lib/*"],
-      "@/app/*": ["app/*"]
+      "@/*": ["./*"]
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],


### PR DESCRIPTION
The application was failing to resolve path aliases like `@/components/ui/card`, causing a "Module not found" error.

This was caused by an overly specific `paths` configuration in `tsconfig.json`. This commit simplifies the configuration to use a single wildcard alias `"@/*": ["./*"]`, which is a more robust and common way to handle path aliases in Next.js projects.

Additionally, a typo in `jest.config.js` (`moduleNameMapping` instead of `moduleNameMapper`) was corrected to ensure that path aliases also work correctly in the testing environment.