### PR TITLE
fix: Resolve Vercel build errors for PostCSS and path aliases

### DIFF
--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,12 +1,9 @@
-import tailwindcss from '@tailwindcss/postcss';
-import autoprefixer from 'autoprefixer';
-
 /** @type {import('postcss-load-config').Config} */
 const config = {
-  plugins: [
-    tailwindcss,
-    autoprefixer,
-  ],
-};
+  plugins: {
+    '@tailwindcss/postcss': {},
+    'autoprefixer': {},
+  },
+}
 
-export default config;
+export default config


### PR DESCRIPTION
This commit fixes a series of build errors that were occurring during Vercel deployments.

The first set of issues were "Module not found" errors for path aliases like `@/components/ui/card`. This was resolved by:
1.  Simplifying the `paths` configuration in `tsconfig.json` to use a single wildcard alias.
2.  Adding a Webpack alias to `next.config.mjs` to ensure the Vercel build environment can resolve the paths.
3.  Correcting a typo in `jest.config.js` (`moduleNameMapping` to `moduleNameMapper`).

The second set of issues were PostCSS errors related to Tailwind CSS v4. The Vercel build environment required a specific string-based configuration. This was resolved by:
1.  Installing the `@tailwindcss/postcss` package.
2.  Updating `postcss.config.mjs` to use the object syntax with `{'@tailwindcss/postcss': {}}` to be compatible with both Tailwind CSS v4 and the Vercel build environment.