### PR TITLE
fix: Add missing navigation links to clinician portal

### DIFF
--- a/components/dashboard-layout.tsx
+++ b/components/dashboard-layout.tsx
@@ -40,9 +40,10 @@ const patientNavigation = [
 ]
 
 const clinicianNavigation = [
-  { name: "Clinician Portal", href: "/dashboard/clinician", icon: Home },
-  // Future clinician-specific links will go here
-  // e.g., { name: "Patient Management", href: "/dashboard/clinician/patients", icon: Users },
+  { name: "Clinician Home", href: "/dashboard/clinician", icon: Home },
+  { name: "Patient Management", href: "/dashboard/clinician/patients", icon: Users },
+  { name: "Appointments", href: "/dashboard/clinician/appointments", icon: Calendar },
+  { name: "Bulk Data Export", href: "/dashboard/clinician/bulk-data", icon: Download },
 ]
 
 interface DashboardLayoutProps {


### PR DESCRIPTION
This commit fixes a bug where the navigation sidebar for the new clinician portal was missing links to the implemented features.

Links to "Patient Management", "Appointment Management", and "Bulk Data Export" have been added to the `clinicianNavigation` array in the `DashboardLayout` component. This makes the new pages accessible after a clinician logs in.