### PR TITLE
feat: Display all resource types from bulk import

### DIFF
--- a/app/dashboard/clinician/page.tsx
+++ b/app/dashboard/clinician/page.tsx
@@ -8,6 +8,13 @@ import { PatientTable } from '@/components/resource-tables/patient-table'
 import { AppointmentTable } from '@/components/resource-tables/appointment-table'
 import { ConditionTable } from '@/components/resource-tables/condition-table'
 import { MedicationTable } from '@/components/resource-tables/medication-table'
+import { AllergyTable } from '@/components/resource-tables/allergy-table'
+import { PractitionerTable } from '@/components/resource-tables/practitioner-table'
+import { DiagnosticReportTable } from '@/components/resource-tables/diagnostic-report-table'
+import { ImmunizationTable } from '@/components/resource-tables/immunization-table'
+import { ObservationTable } from '@/components/resource-tables/observation-table'
+import { DocumentReferenceTable } from '@/components/resource-tables/document-reference-table'
+import { ProcedureTable } from '@/components/resource-tables/procedure-table'
 
 type BulkImportStatus =
   | 'idle'
@@ -43,6 +50,53 @@ interface Medication {
   subject: { display: string }
 }
 
+interface AllergyIntolerance {
+  id: string
+  code: { text: string }
+  patient: { display: string }
+}
+
+interface Practitioner {
+  id: string
+  name: { text: string }[]
+}
+
+interface DiagnosticReport {
+  id: string
+  code: { text: string }
+  subject: { display: string }
+  conclusion: string
+}
+
+interface Immunization {
+  id: string
+  vaccineCode: { text: string }
+  patient: { display: string }
+  occurrenceDateTime: string
+}
+
+interface Observation {
+  id: string
+  code: { text: string }
+  subject: { display: string }
+  valueQuantity?: { value: number; unit: string }
+  valueString?: string
+}
+
+interface DocumentReference {
+  id: string
+  description: string
+  subject: { display: string }
+  date: string
+}
+
+interface Procedure {
+  id: string
+  code: { text: string }
+  subject: { display: string }
+  performedDateTime: string
+}
+
 export default function ClinicianDashboardPage() {
   const [importStatus, setImportStatus] = useState<BulkImportStatus>('idle')
   const [statusUrl, setStatusUrl] = useState<string | null>(null)
@@ -56,15 +110,30 @@ export default function ClinicianDashboardPage() {
   const [appointments, setAppointments] = useState<Appointment[]>([])
   const [conditions, setConditions] = useState<Condition[]>([])
   const [medications, setMedications] = useState<Medication[]>([])
+  const [allergies, setAllergies] = useState<AllergyIntolerance[]>([])
+  const [practitioners, setPractitioners] = useState<Practitioner[]>([])
+  const [diagnosticReports, setDiagnosticReports] = useState<DiagnosticReport[]>([])
+  const [immunizations, setImmunizations] = useState<Immunization[]>([])
+  const [observations, setObservations] = useState<Observation[]>([])
+  const [documentReferences, setDocumentReferences] = useState<DocumentReference[]>([])
+  const [procedures, setProcedures] = useState<Procedure[]>([])
 
   const startBulkImport = async () => {
     setImportStatus('starting')
     setError(null)
     setManifest(null)
+    // Reset all data states
     setPatients([])
     setAppointments([])
     setConditions([])
     setMedications([])
+    setAllergies([])
+    setPractitioners([])
+    setDiagnosticReports([])
+    setImmunizations([])
+    setObservations([])
+    setDocumentReferences([])
+    setProcedures([])
     try {
       const response = await fetch('/api/clinician/bulk-data/start', {
         method: 'POST',
@@ -119,9 +188,30 @@ export default function ClinicianDashboardPage() {
         case 'MedicationRequest':
           setMedications(data)
           break
+        case 'AllergyIntolerance':
+          setAllergies(data)
+          break
+        case 'Practitioner':
+          setPractitioners(data)
+          break
+        case 'DiagnosticReport':
+          setDiagnosticReports(data)
+          break
+        case 'Immunization':
+          setImmunizations(data)
+          break
+        case 'Observation':
+          setObservations(data)
+          break
+        case 'DocumentReference':
+          setDocumentReferences(data)
+          break
+        case 'Procedure':
+          setProcedures(data)
+          break
         default:
           console.warn(`No display logic for resource type: ${resourceType}`)
-          setError(`Display logic for ${resourceType} is not implemented.`)
+          setError(`Display logic for ${resourceType} is not implemented yet.`)
       }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An unknown error occurred')
@@ -257,6 +347,13 @@ export default function ClinicianDashboardPage() {
           <AppointmentTable appointments={appointments} />
           <ConditionTable conditions={conditions} />
           <MedicationTable medications={medications} />
+          <AllergyTable allergies={allergies} />
+          <PractitionerTable practitioners={practitioners} />
+          <DiagnosticReportTable reports={diagnosticReports} />
+          <ImmunizationTable immunizations={immunizations} />
+          <ObservationTable observations={observations} />
+          <DocumentReferenceTable documents={documentReferences} />
+          <ProcedureTable procedures={procedures} />
         </div>
       </div>
     </DashboardLayout>

--- a/components/resource-tables/allergy-table.tsx
+++ b/components/resource-tables/allergy-table.tsx
@@ -1,0 +1,49 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface AllergyIntolerance {
+  id: string
+  code: { text: string }
+  patient: { display: string }
+}
+
+interface AllergyTableProps {
+  allergies: AllergyIntolerance[]
+}
+
+export function AllergyTable({ allergies }: AllergyTableProps) {
+  if (allergies.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Allergies</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Substance</TableHead>
+              <TableHead>Patient</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {allergies.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell>{item.code.text}</TableCell>
+                <TableCell>{item.patient.display}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/resource-tables/diagnostic-report-table.tsx
+++ b/components/resource-tables/diagnostic-report-table.tsx
@@ -1,0 +1,52 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface DiagnosticReport {
+  id: string
+  code: { text: string }
+  subject: { display: string }
+  conclusion: string
+}
+
+interface DiagnosticReportTableProps {
+  reports: DiagnosticReport[]
+}
+
+export function DiagnosticReportTable({ reports }: DiagnosticReportTableProps) {
+  if (reports.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Diagnostic Reports</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Report</TableHead>
+              <TableHead>Conclusion</TableHead>
+              <TableHead>Patient</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {reports.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell>{item.code.text}</TableCell>
+                <TableCell>{item.conclusion}</TableCell>
+                <TableCell>{item.subject.display}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/resource-tables/document-reference-table.tsx
+++ b/components/resource-tables/document-reference-table.tsx
@@ -1,0 +1,61 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface DocumentReference {
+  id: string
+  description: string
+  subject: { display: string }
+  date: string
+}
+
+interface DocumentReferenceTableProps {
+  documents: DocumentReference[]
+}
+
+const formatDate = (dateString?: string): string => {
+  if (!dateString) return 'N/A'
+  try {
+    return new Date(dateString).toLocaleDateString()
+  } catch {
+    return dateString
+  }
+}
+
+export function DocumentReferenceTable({ documents }: DocumentReferenceTableProps) {
+  if (documents.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Document References</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Document</TableHead>
+              <TableHead>Patient</TableHead>
+              <TableHead>Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {documents.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell>{item.description}</TableCell>
+                <TableCell>{item.subject.display}</TableCell>
+                <TableCell>{formatDate(item.date)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/resource-tables/immunization-table.tsx
+++ b/components/resource-tables/immunization-table.tsx
@@ -1,0 +1,61 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface Immunization {
+  id: string
+  vaccineCode: { text: string }
+  patient: { display: string }
+  occurrenceDateTime: string
+}
+
+interface ImmunizationTableProps {
+  immunizations: Immunization[]
+}
+
+const formatDate = (dateString?: string): string => {
+  if (!dateString) return 'N/A'
+  try {
+    return new Date(dateString).toLocaleDateString()
+  } catch {
+    return dateString
+  }
+}
+
+export function ImmunizationTable({ immunizations }: ImmunizationTableProps) {
+  if (immunizations.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Immunizations</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Vaccine</TableHead>
+              <TableHead>Patient</TableHead>
+              <TableHead>Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {immunizations.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell>{item.vaccineCode.text}</TableCell>
+                <TableCell>{item.patient.display}</TableCell>
+                <TableCell>{formatDate(item.occurrenceDateTime)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/resource-tables/observation-table.tsx
+++ b/components/resource-tables/observation-table.tsx
@@ -1,0 +1,63 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface Observation {
+  id: string
+  code: { text: string }
+  subject: { display: string }
+  valueQuantity?: { value: number; unit: string }
+  valueString?: string
+}
+
+interface ObservationTableProps {
+  observations: Observation[]
+}
+
+const formatValue = (obs: Observation): string => {
+  if (obs.valueQuantity) {
+    return `${obs.valueQuantity.value} ${obs.valueQuantity.unit}`
+  }
+  if (obs.valueString) {
+    return obs.valueString
+  }
+  return 'N/A'
+}
+
+export function ObservationTable({ observations }: ObservationTableProps) {
+  if (observations.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Observations</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Observation</TableHead>
+              <TableHead>Value</TableHead>
+              <TableHead>Patient</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {observations.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell>{item.code.text}</TableCell>
+                <TableCell>{formatValue(item)}</TableCell>
+                <TableCell>{item.subject.display}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/resource-tables/practitioner-table.tsx
+++ b/components/resource-tables/practitioner-table.tsx
@@ -1,0 +1,46 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface Practitioner {
+  id: string
+  name: { text: string }[]
+}
+
+interface PractitionerTableProps {
+  practitioners: Practitioner[]
+}
+
+export function PractitionerTable({ practitioners }: PractitionerTableProps) {
+  if (practitioners.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Practitioners</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Name</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {practitioners.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell>{item.name?.[0]?.text || 'N/A'}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/resource-tables/procedure-table.tsx
+++ b/components/resource-tables/procedure-table.tsx
@@ -1,0 +1,61 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+
+interface Procedure {
+  id: string
+  code: { text: string }
+  subject: { display: string }
+  performedDateTime: string
+}
+
+interface ProcedureTableProps {
+  procedures: Procedure[]
+}
+
+const formatDate = (dateString?: string): string => {
+  if (!dateString) return 'N/A'
+  try {
+    return new Date(dateString).toLocaleDateString()
+  } catch {
+    return dateString
+  }
+}
+
+export function ProcedureTable({ procedures }: ProcedureTableProps) {
+  if (procedures.length === 0) return null
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Procedures</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Procedure</TableHead>
+              <TableHead>Patient</TableHead>
+              <TableHead>Date</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {procedures.map((item) => (
+              <TableRow key={item.id}>
+                <TableCell>{item.code.text}</TableCell>
+                <TableCell>{item.subject.display}</TableCell>
+                <TableCell>{formatDate(item.performedDateTime)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}


### PR DESCRIPTION
- Implements the display for all remaining resource types from the bulk data export manifest, including AllergyIntolerance, Practitioner, DiagnosticReport, etc.
- Creates separate, reusable table components for each new resource type to maintain a clean UI.
- Expands the dashboard's state and data fetching logic to handle all new data types.