### PR TITLE
feat(patients): Populate patient list from bulk data cache

### DIFF
--- a/app/api/clinician/bulk-data/fetch-file/route.ts
+++ b/app/api/clinician/bulk-data/fetch-file/route.ts
@@ -39,10 +39,10 @@ export async function POST(request: NextRequest) {
   }
 
   try {
-    const { fileUrl } = await request.json()
+    const { fileUrl, fileType } = await request.json()
 
-    if (!fileUrl) {
-      return NextResponse.json({ error: 'fileUrl is required' }, { status: 400 })
+    if (!fileUrl || !fileType) {
+      return NextResponse.json({ error: 'fileUrl and fileType are required' }, { status: 400 })
     }
 
     const { db } = await connectToDatabase()
@@ -74,6 +74,7 @@ export async function POST(request: NextRequest) {
     // Store in cache
     await cacheCollection.insertOne({
       fileUrl,
+      fileType,
       data,
       createdAt: new Date(),
     })

--- a/app/api/clinician/patients/route.ts
+++ b/app/api/clinician/patients/route.ts
@@ -31,7 +31,7 @@ function getAccessToken(): string | null {
   }
 }
 
-import { Patient, FHIRBundle } from '@/lib/types/fhir';
+import { connectToDatabase } from '@/lib/mongodb';
 
 export async function GET(request: NextRequest) {
   const accessToken = getAccessToken();
@@ -43,35 +43,26 @@ export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url);
     const fetchAll = searchParams.get('_fetchAll') === 'true';
-    const epicClient = new EpicFHIRClient('clinician');
 
     if (fetchAll) {
-      let allPatients: Patient[] = [];
-      let nextUrl: string | undefined;
+      const { db } = await connectToDatabase();
+      const cacheCollection = db.collection('bulk_data_files');
 
-      // Initial search with a larger page count
-      const initialSearchCriteria = { _count: '100' };
-      let bundle: FHIRBundle = await epicClient.searchPatients(accessToken, initialSearchCriteria);
+      const patientDataCache = await cacheCollection.findOne(
+        { fileType: 'Patient' },
+        { sort: { createdAt: -1 } }
+      );
 
-      if (bundle.entry) {
-        allPatients = allPatients.concat(bundle.entry.map((e: any) => e.resource));
+      if (patientDataCache && Array.isArray(patientDataCache.data)) {
+        const patients = patientDataCache.data;
+        return NextResponse.json({ entry: patients.map(p => ({ resource: p })) });
+      } else {
+        // No patient data in cache, return empty list
+        return NextResponse.json({ entry: [] });
       }
-
-      nextUrl = bundle.link?.find(l => l.relation === 'next')?.url;
-
-      while (nextUrl) {
-        const nextBundle: FHIRBundle = await epicClient.fetchByUrl(nextUrl, accessToken);
-        if (nextBundle.entry) {
-          allPatients = allPatients.concat(nextBundle.entry.map((e: any) => e.resource));
-        }
-        nextUrl = nextBundle.link?.find(l => l.relation === 'next')?.url;
-      }
-
-      // Return in a format consistent with a bundle search result
-      return NextResponse.json({ entry: allPatients.map(p => ({ resource: p })) });
     }
 
-    // Existing search logic for single-page results
+    // Existing search logic for single-page results from live API
     const searchCriteria = {
       family: searchParams.get('family') || undefined,
       given: searchParams.get('given') || undefined,
@@ -80,6 +71,7 @@ export async function GET(request: NextRequest) {
       _count: searchParams.get('_count') || '10', // Default to 10 results
     };
 
+    const epicClient = new EpicFHIRClient('clinician');
     const searchResults = await epicClient.searchPatients(accessToken, searchCriteria);
 
     return NextResponse.json(searchResults);

--- a/app/dashboard/clinician/bulk-data/page.tsx
+++ b/app/dashboard/clinician/bulk-data/page.tsx
@@ -22,6 +22,56 @@ export default function BulkDataExportPage() {
   const [progress, setProgress] = useState<string | null>(null);
   const [manifest, setManifest] = useState<{ output: ManifestFile[] } | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [downloadingUrl, setDownloadingUrl] = useState<string | null>(null);
+
+  const handleDownload = async (fileUrl: string, fileType: string) => {
+    if (downloadingUrl) return;
+    setDownloadingUrl(fileUrl);
+
+    try {
+      const response = await fetch('/api/clinician/bulk-data/fetch-file', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ fileUrl, fileType }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.details || `Failed to download file for ${fileType}`);
+      }
+
+      const { data } = await response.json();
+
+      const ndjson = data.map((item: any) => JSON.stringify(item)).join('\n');
+
+      const blob = new Blob([ndjson], { type: 'application/fhir+ndjson' });
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${fileType}.ndjson`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      window.URL.revokeObjectURL(url);
+
+      toast({
+        title: "Download Started",
+        description: `Your download for ${fileType}.ndjson has started.`,
+      });
+
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "An unknown error occurred.";
+      toast({
+        title: "Download Error",
+        description: errorMessage,
+        variant: "destructive",
+      });
+    } finally {
+      setDownloadingUrl(null);
+    }
+  };
 
   const handleStartExport = async () => {
     setJobStatus('starting');
@@ -66,6 +116,37 @@ export default function BulkDataExportPage() {
         setJobStatus('complete');
         setStatusUrl(null); // Stop polling
         toast({ title: "Export Complete!", description: "Your data is ready for download." });
+
+        // Automatically trigger caching of patient data in the background
+        const patientFile = data.manifest.output.find((f: ManifestFile) => f.type === 'Patient');
+        if (patientFile) {
+          console.log('Found patient data in manifest, triggering background cache.');
+          fetch('/api/clinician/bulk-data/fetch-file', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              fileUrl: patientFile.url,
+              fileType: patientFile.type,
+            }),
+          })
+          .then(async (res) => {
+            if (res.ok) {
+              console.log('Patient data pre-cached successfully.');
+              toast({
+                title: "Data Synced",
+                description: "Patient list has been updated in the background.",
+              });
+            } else {
+              const errorData = await res.json();
+              console.error('Failed to pre-cache patient data:', errorData.details);
+            }
+          })
+          .catch(err => {
+            console.error('Error during background patient data caching:', err);
+          });
+        }
       }
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "An unknown error occurred.";
@@ -141,12 +222,18 @@ export default function BulkDataExportPage() {
                       {file.count && <p className="text-sm text-muted-foreground">{file.count.toLocaleString()} records</p>}
                     </div>
                   </div>
-                  <a href={file.url} target="_blank" rel="noopener noreferrer">
-                    <Button variant="outline">
+                  <Button
+                    variant="outline"
+                    onClick={() => handleDownload(file.url, file.type)}
+                    disabled={!!downloadingUrl}
+                  >
+                    {downloadingUrl === file.url ? (
+                      <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    ) : (
                       <Download className="w-4 h-4 mr-2" />
-                      Download
-                    </Button>
-                  </a>
+                    )}
+                    {downloadingUrl === file.url ? 'Downloading...' : 'Download'}
+                  </Button>
                 </div>
               ))}
             </CardContent>

--- a/app/dashboard/clinician/patients/new/page.tsx
+++ b/app/dashboard/clinician/patients/new/page.tsx
@@ -87,10 +87,8 @@ export default function NewPatientPage() {
       <div className="space-y-6">
         <div>
           <Link href="/dashboard/clinician/patients" className="flex items-center text-sm text-muted-foreground hover:text-foreground mb-4">
-            <>
-              <ArrowLeft className="w-4 h-4 mr-2" />
-              Back to Patient Management
-            </>
+            <ArrowLeft className="w-4 h-4 mr-2" />
+            Back to Patient Management
           </Link>
           <h1 className="text-3xl font-bold text-foreground">Add New Patient</h1>
           <p className="text-muted-foreground">Enter the details for the new patient record.</p>

--- a/lib/epic-client.ts
+++ b/lib/epic-client.ts
@@ -212,13 +212,11 @@ export class EpicFHIRClient {
    * Make authenticated FHIR API request with retry logic
    */
   private async makeRequest<T>(
-    endpointOrUrl: string,
+    endpoint: string,
     accessToken: string,
     options: RequestInit = {}
   ): Promise<T> {
-    const url = endpointOrUrl.startsWith('http')
-      ? endpointOrUrl
-      : `${this.config.baseUrl}${endpointOrUrl}`;
+    const url = `${this.config.baseUrl}${endpoint}`;
     let retryCount = 0;
     const maxRetries = 3;
 
@@ -258,7 +256,7 @@ export class EpicFHIRClient {
 
           this.auditLog('FHIR_REQUEST_ERROR', {
             timestamp: new Date().toISOString(),
-            endpoint: endpointOrUrl,
+            endpoint,
             status: response.status,
             error: operationOutcome?.issue?.[0]?.diagnostics || errorBody
           });
@@ -274,7 +272,7 @@ export class EpicFHIRClient {
         // Log successful request (without PHI)
         this.auditLog('FHIR_REQUEST_SUCCESS', {
           timestamp: new Date().toISOString(),
-          endpoint: endpointOrUrl,
+          endpoint,
           resourceType: data.resourceType || 'Bundle'
         });
 
@@ -344,10 +342,6 @@ export class EpicFHIRClient {
     return this.makeRequest<OperationOutcome>(`Patient/${patientId}`, accessToken, {
       method: 'DELETE'
     });
-  }
-
-  async fetchByUrl<T>(url: string, accessToken: string): Promise<T> {
-    return this.makeRequest<T>(url, accessToken);
   }
 
   // Appointment Operations


### PR DESCRIPTION
- Implements a new workflow to populate the patient management page with a full list of patients sourced from the bulk data export feature.
- When a bulk export completes, the patient data file is now automatically fetched and cached in the background.
- The patient management page now loads this cached data by default, providing an immediate, comprehensive view of all patients in the system.
- The download button on the bulk data page has been improved with loading states and now populates the cache if it's missed.
- This approach replaces a previous, flawed implementation that attempted to query all patients from the live FHIR API, which is not supported.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - One-click downloads with progress indicator, disabled state to prevent multiple downloads, and clearer success/error toasts.
  - Automatic background sync of Patient data after export completes to speed up subsequent views.
- Performance
  - “Fetch all” Patients now serves from cached bulk data when available, improving load times and reducing external requests.
- UI/Style
  - Download actions use buttons with icons and spinners instead of plain links.
  - Minor cleanup to back-link structure with no visible behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->