### PR TITLE
fix(billing): Remove initial data load on clinician billing page

### DIFF
--- a/app/dashboard/clinician/billing/page.tsx
+++ b/app/dashboard/clinician/billing/page.tsx
@@ -21,10 +21,14 @@ export default function ClinicianBillingPage() {
   const { toast } = useToast();
 
   const fetchBillingData = async (patientId = "") => {
+    if (!patientId) {
+      toast({ title: "Error", description: "Please enter a Patient ID to search.", variant: "destructive" });
+      return;
+    }
     setIsLoading(true);
     setError(null);
     try {
-      const query = patientId ? `?patient=${patientId}` : "";
+      const query = `?patient=${patientId}`;
       const response = await fetch(`/api/clinician/billing${query}`);
       if (!response.ok) {
         const errorData = await response.json();
@@ -38,11 +42,6 @@ export default function ClinicianBillingPage() {
       setIsLoading(false);
     }
   };
-
-  // Fetch all transactions on initial load
-  useEffect(() => {
-    fetchBillingData();
-  }, []);
 
   const handleSearch = (e: FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
- Removes the `useEffect` hook that was triggering a data fetch on the initial load of the clinician billing page.
- This was causing an error because the underlying FHIR API for `ExplanationOfBenefit` requires a `patient` parameter for searching and does not support fetching all records at once.
- The page now correctly starts with an empty state, requiring the clinician to search for a specific patient to view their billing data, which aligns with the API's constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Billing search now requires a Patient ID; attempts without one show a clear error message.
  - Results load only after entering a valid Patient ID; the page no longer auto-loads billing data.

- Bug Fixes
  - Prevented empty searches and unnecessary requests by enforcing Patient ID input.
  - Reduced accidental exposure of unrelated billing data by eliminating the initial auto-fetch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->